### PR TITLE
fix: respect `preview.max_width` for video thumbnails

### DIFF
--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -60,7 +60,7 @@ function M:preload(job)
 		"-i", tostring(job.file.url),
 		"-vframes", 1,
 		"-q:v", qv,
-		"-vf", string.format("scale=-1:'min(%d,ih)':flags=fast_bilinear", rt.preview.max_height),
+		"-vf", string.format("scale=w=%d:h=%d:force_original_aspect_ratio=decrease:flags=fast_bilinear", rt.preview.max_width , rt.preview.max_height),
 		"-f", "image2",
 		"-y", tostring(cache),
 	}):status()


### PR DESCRIPTION
Currently, Yazi only scales thumbnails to `preview.max_height`, which means that thumbnails of videos in landscape orientation are unnecessarily large.

```
max_width       = 600
max_height      = 900
image_quality   = 75
```

### Before:
File size: 131 kB
Image size: 1600x900
On the left is a preview in Yazi, and on the right is a generated thumbnail.
![before](https://github.com/user-attachments/assets/8a18f4eb-c53a-430f-819e-cffb735370dd)



### After:
File size: 28 kB
Image size: 600x338
![after](https://github.com/user-attachments/assets/716c4bab-6fb7-4c25-8201-c49dff362ed8)
